### PR TITLE
Fixing _build_function

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -163,6 +163,7 @@ function parse_eval_dict(ex::AbstractString, locals::Dict)
     )
 end
 
+#=
 function _build_function(name::String, expr::Expr, args::Symbol...)
     function_name = Symbol(name, args...)
     inner_function_expr = quote
@@ -174,6 +175,11 @@ function _build_function(name::String, expr::Expr, args::Symbol...)
     eval(inner_function_expr)
 
     return eval(function_name)
+end
+=#
+
+function _build_function(name::String, expr::Expr, args::Symbol...)
+    return eval(:(($(args...),) -> $expr))
 end
 
 function _create_params(kw_args...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,9 @@
 using SafeTestsets
 using Test
 
-#@safetestset "Quality Assurance" begin
-#    include("qa.jl")
-#end
+@safetestset "Quality Assurance" begin
+    include("qa.jl")
+end
 
 @safetestset "Axioms" begin
     include("axioms.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,9 @@
 using SafeTestsets
 using Test
 
-@safetestset "Quality Assurance" begin
-    include("qa.jl")
-end
+#@safetestset "Quality Assurance" begin
+#    include("qa.jl")
+#end
 
 @safetestset "Axioms" begin
     include("axioms.jl")


### PR DESCRIPTION
Removed the named function inside _build_function that caused excessive warnings during testing so it probably also fixes actual problems. I need to double check this against the python package results 